### PR TITLE
Ensembl file downloader had a "retry forever" bug with timeouts.

### DIFF
--- a/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblBatchLookup.java
+++ b/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblBatchLookup.java
@@ -110,13 +110,15 @@ public class EnsemblBatchLookup  extends FileRetriever
 				try
 				{
 					boolean requestDone = false;
+					EnsemblServiceResponseProcessor responseProcessor = new EnsemblServiceResponseProcessor();
 					while (!requestDone)
 					{
+						
 						logger.debug("Submitting batch request - {}", index);
 						try (CloseableHttpClient postClient = HttpClients.createDefault();
 								CloseableHttpResponse postResponse = postClient.execute(post);)
 						{
-							EnsemblServiceResult result = EnsemblServiceResponseProcessor.processResponse(postResponse);
+							EnsemblServiceResult result = responseProcessor.processResponse(postResponse);
 							// This means we need to wait, and then retry
 							if (!result.getWaitTime().equals(Duration.ZERO))
 							{

--- a/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblFileRetriever.java
+++ b/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblFileRetriever.java
@@ -208,13 +208,14 @@ public class EnsemblFileRetriever extends FileRetriever
 					logger.trace("URI: "+get.getURI());
 					
 					boolean done = false;
-	
+					EnsemblServiceResponseProcessor responseProcessor = new EnsemblServiceResponseProcessor();
 					while (!done)
 					{
+						
 						try (CloseableHttpClient getClient = HttpClients.createDefault();
 								CloseableHttpResponse getResponse = getClient.execute(get);)
 						{
-							EnsemblServiceResult result = EnsemblServiceResponseProcessor.processResponse(getResponse);
+							EnsemblServiceResult result = responseProcessor.processResponse(getResponse);
 							if (!result.getWaitTime().equals(Duration.ZERO))
 							{
 								logger.info("Need to wait: {} seconds.", result.getWaitTime().getSeconds());


### PR DESCRIPTION
The bug is now fixed, though it might be nice to parameterize the
*number* of allowed retried for timeouts.