### PR TITLE
Fix for BRENDA species-specific ReferenceDatabase object names.

### DIFF
--- a/src/main/java/org/reactome/addlinks/AddLinks.java
+++ b/src/main/java/org/reactome/addlinks/AddLinks.java
@@ -316,9 +316,33 @@ public class AddLinks
 			
 		}
 		
+		// Now... we need to clean up some of the species-specific Reference Database names. Specifically, BRENDA was causing problems for some external team
+		// that was using a file which contained strings of the form "BRENDA (Species Name)". So we will change name[0] for BRENDA ReferenceDatabase objects
+		// to "BRENDA" but leave the _displayName as "BRENDA (Species Name)".
+		// This *CANNOT* be done earlier in the process as the species name in the ReferenceDatabase name is used to do lookups to get the correct species-specific
+		// ReferenceDatabase object. Another option would be to modify the data model by adding a new "species" attribute to the ReferenceDatabase type, but
+		// I'm not sure anyone else will go along with that...
+		fixBrendaRefDBNames();
+		
 		logger.info("Process complete.");
 	}
 
+	private void fixBrendaRefDBNames() throws Exception
+	{
+		logger.info("Fixing BRENDA reference database names.");
+		@SuppressWarnings("unchecked")
+		List<GKInstance> brendaRefDBs = (List<GKInstance>) this.dbAdapter.fetchInstanceByAttribute(ReactomeJavaConstants.ReferenceDatabase, ReactomeJavaConstants.name, "LIKE", "%BRENDA%");
+		for (GKInstance brendaRefDB : brendaRefDBs)
+		{
+			@SuppressWarnings("unchecked")
+			List<String> names = (List<String>) brendaRefDB.getAttributeValue(ReactomeJavaConstants.name);
+			names.set(0, "BRENDA");
+			brendaRefDB.setAttributeValue(ReactomeJavaConstants.name, names);
+			this.dbAdapter.updateInstanceAttribute(brendaRefDB, ReactomeJavaConstants.name);
+			logger.info("BRENDA RefDB {} now has names: {}", brendaRefDB, brendaRefDB.getAttributeValue(ReactomeJavaConstants.name));
+		}
+	}
+	
 	@SuppressWarnings("unchecked")
 	private void purgeUnusedRefDBs()
 	{

--- a/src/main/java/org/reactome/addlinks/db/ReferenceDatabaseCreator.java
+++ b/src/main/java/org/reactome/addlinks/db/ReferenceDatabaseCreator.java
@@ -107,13 +107,14 @@ public class ReferenceDatabaseCreator
 	 * @param names - A list of names for this ReferenceDatabase. If *none* of these values are already in the database, then a new ReferenceDatabase
 	 * will be created and these names will be associated with it. If *any* of these names already exist, then the other names will be associated with it.
 	 * The URLs will *not* be updated in the case that a ReferenceDatabase name is pre-existing in the database.
+	 * @return - The ID of the reference database, whether it was created by this function call, or if it was pre-existing.
 	 * @throws Exception 
 	 */
-	public void createReferenceDatabaseToURL(String url, String accessUrl, String ... names) throws Exception
+	public long createReferenceDatabaseToURL(String url, String accessUrl, String ... names) throws Exception
 	{
 		//First, let's check that the Reference Database doesn't already exist. all we have to go on is the name...
 		SchemaClass refDBClass = adapter.getSchema().getClassByName(ReactomeJavaConstants.ReferenceDatabase);
-		
+		long refDBID = -1L;
 		try
 		{
 			SchemaAttribute dbNameAttrib = refDBClass.getAttribute(ReactomeJavaConstants.name);
@@ -152,7 +153,7 @@ public class ReferenceDatabaseCreator
 				newReferenceDB.setAttributeValue(ReactomeJavaConstants.accessUrl, accessUrl);
 				newReferenceDB.setDbAdaptor(this.adapter);
 				InstanceDisplayNameGenerator.setDisplayName(newReferenceDB);
-				this.adapter.storeInstance(newReferenceDB);
+				refDBID = this.adapter.storeInstance(newReferenceDB);
 				logger.info("New ReferenceDatabase has been created: {}", newReferenceDB);
 			}
 			//Othwerwise, some ReferenceDatabase object(s) already exist with some of the names given here. So, we need to update it with the new names. 
@@ -170,6 +171,7 @@ public class ReferenceDatabaseCreator
 						logger.info("Adding the name {} to the existing ReferenceDatabase {}",name,preexistingRefDB + "( " + preexistingRefDB.getAttributeValuesList(ReactomeJavaConstants.name).toString() + " )");
 						preexistingRefDB.addAttributeValue(dbNameAttrib, name);
 						this.adapter.updateInstanceAttribute(preexistingRefDB, dbNameAttrib);
+						refDBID = preexistingRefDB.getDBID();
 					}
 				}
 			}
@@ -180,5 +182,6 @@ public class ReferenceDatabaseCreator
 			logger.error("Error while trying to create a Reference Database object: "+e.getMessage());
 			throw e;
 		}
+		return refDBID;
 	}
 }


### PR DESCRIPTION
See: https://github.com/reactome/add-links/issues/76

Also: Creating a ReferenceDatabase object will now return the DB_ID of that object.