### PR TITLE
Memory fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
 			<artifactId>release-common-lib</artifactId>
 			<version>1.0.2</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.6</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblBioMartRetriever.java
+++ b/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblBioMartRetriever.java
@@ -102,18 +102,21 @@ public class EnsemblBioMartRetriever extends FileRetriever {
      * @throws IOException - Thrown when unable to write data to file.
      */
     private void queryBioMartAndStoreData(String biomartSpeciesName, String biomartQueryFilePath, String biomartDataType, String fileSuffix) throws IOException {
-
-        Set<String> biomartResponseLines = new HashSet<>();
-        logger.info("Retrieving data associated with query ID: " + biomartDataType);
-        try {
-            biomartResponseLines = queryBioMart(getBioMartIdentifierQuery(biomartQueryFilePath, biomartSpeciesName, biomartDataType), biomartDataType);
-        } catch (Exception e) {
-            logger.error("Unable to retrieve data associated with query ID: " + biomartDataType, e);
-            e.printStackTrace();
-        }
-
         String biomartFilename = this.destination + biomartSpeciesName + fileSuffix;
-        storeBioMartData(biomartFilename, biomartResponseLines);
+        if (!Files.exists(Paths.get(biomartFilename))) {
+            Set<String> biomartResponseLines = new HashSet<>();
+            logger.info("Retrieving data associated with query ID: {}", biomartDataType);
+            try {
+                biomartResponseLines = queryBioMart(getBioMartIdentifierQuery(biomartQueryFilePath, biomartSpeciesName, biomartDataType), biomartDataType);
+            } catch (Exception e) {
+                logger.error("Unable to retrieve data associated with query ID: " + biomartDataType, e);
+                e.printStackTrace();
+            }
+            storeBioMartData(biomartFilename, biomartResponseLines);
+        }
+        else {
+        	logger.info("{} already exists. It is *assumed* to be complete, and will not be downloaded.", biomartFilename);
+        }
     }
 
     /**

--- a/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblBioMartRetriever.java
+++ b/src/main/java/org/reactome/addlinks/dataretrieval/ensembl/EnsemblBioMartRetriever.java
@@ -103,6 +103,7 @@ public class EnsemblBioMartRetriever extends FileRetriever {
      */
     private void queryBioMartAndStoreData(String biomartSpeciesName, String biomartQueryFilePath, String biomartDataType, String fileSuffix) throws IOException {
         String biomartFilename = this.destination + biomartSpeciesName + fileSuffix;
+        logger.info("Querying Biomart for species: {}; data type: {}", biomartSpeciesName, biomartDataType);
         if (!Files.exists(Paths.get(biomartFilename))) {
             Set<String> biomartResponseLines = new HashSet<>();
             logger.info("Retrieving data associated with query ID: {}", biomartDataType);

--- a/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
+++ b/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
@@ -1,7 +1,12 @@
 package org.reactome.addlinks.fileprocessors;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -10,17 +15,25 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stax.StAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetabolitesFileProcessor.HMDBFileMappingKeys, ? extends Collection<String>>>
 {
+	private static final Object METABOLITE_ELEMENT_NAME = "metabolite";
+
+
 	public HmdbMetabolitesFileProcessor(String processorName)
 	{
 		super(processorName);
@@ -65,13 +78,14 @@ public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetaboli
 				//String dirToFile = this.unzipFile(this.pathToFile);
 				String inputFilename = dirToHmdbFiles + "/" + this.pathToFile.getFileName().toString().replaceAll(".zip", ".xml");
 				
-				//Transform the OrphaNet XML into a more usable CSV file.
+				//Transform the HMDB XML into a more usable CSV file.
 				Source source = new StreamSource(this.getClass().getClassLoader().getResourceAsStream("hmdb_metabolites_transform.xsl"));
-				Transformer transformer = factory.newTransformer(source);
-				Source xmlSource = new StreamSource(inputFilename);
+//				Transformer transformer = factory.newTransformer(source);
+//				Source xmlSource = new StreamSource(inputFilename);
 				String outfileName = inputFilename + ".transformed.tsv";
-				Result outputTarget =  new StreamResult(new File(outfileName));
-				transformer.transform(xmlSource, outputTarget);
+//				Result outputTarget =  new StreamResult(new File(outfileName));
+//				transformer.transform(xmlSource, outputTarget);
+				this.transformXmlToTsv(inputFilename, outfileName);
 				
 				//Now we need to read the file.
 				Files.readAllLines(Paths.get(outfileName)).stream().forEach(line -> 
@@ -94,16 +108,16 @@ public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetaboli
 					hmdb2ChebiAndUniprot.put(parts[0], hmdbVals);
 				});
 			}
-			catch (TransformerConfigurationException e)
-			{
-				e.printStackTrace();
-				throw new Error(e);
-			}
-			catch (TransformerException e)
-			{
-				e.printStackTrace();
-				throw new Error(e);
-			}
+//			catch (TransformerConfigurationException e)
+//			{
+//				e.printStackTrace();
+//				throw new Error(e);
+//			}
+//			catch (TransformerException e)
+//			{
+//				e.printStackTrace();
+//				throw new Error(e);
+//			}
 			catch (IOException e)
 			{
 				e.printStackTrace();
@@ -130,4 +144,54 @@ public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetaboli
 		return null;
 	}
 
+	
+	private void transformXmlToTsv(String inputFilename, String outfileName)
+	{
+		
+		try(OutputStream outStream = new FileOutputStream(outfileName);)
+		{
+			XMLInputFactory xif = XMLInputFactory.newInstance();
+			XMLStreamReader xsr = xif.createXMLStreamReader(new FileReader(inputFilename));
+			xsr.nextTag();
+			Source source = new StreamSource(this.getClass().getClassLoader().getResourceAsStream("hmdb_metabolites_transform.xsl"));
+			TransformerFactory factory = TransformerFactory.newInstance();
+			Transformer transformer = factory.newTransformer(source);
+			
+			while (xsr.nextTag() == XMLStreamConstants.START_ELEMENT)
+			{
+				if (xsr.getName().getLocalPart().equals(METABOLITE_ELEMENT_NAME))
+				{
+					StAXSource src = new StAXSource(xsr);
+					Result result = new StreamResult(outStream);
+					transformer.transform(src, result);
+				}
+			}
+			xsr.close();
+		}
+		catch (FileNotFoundException e ) 
+		{
+			logger.error("Input XML file was not found!", e);
+			e.printStackTrace();
+		}
+		catch (XMLStreamException e)
+		{
+			logger.error("Error streaming XML file!", e);
+			e.printStackTrace();	
+		}
+		catch (TransformerConfigurationException e)
+		{
+			logger.error("Error with XSL file!", e);
+			e.printStackTrace();
+		}
+		catch (TransformerException e)
+		{
+			logger.error("Data transformation error!", e);
+			e.printStackTrace();
+		}
+		catch (IOException e)
+		{
+			logger.error("I/O Error", e);
+			e.printStackTrace();
+		}
+	}
 }

--- a/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
+++ b/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
@@ -79,12 +79,7 @@ public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetaboli
 				String inputFilename = dirToHmdbFiles + "/" + this.pathToFile.getFileName().toString().replaceAll(".zip", ".xml");
 				
 				//Transform the HMDB XML into a more usable CSV file.
-				Source source = new StreamSource(this.getClass().getClassLoader().getResourceAsStream("hmdb_metabolites_transform.xsl"));
-//				Transformer transformer = factory.newTransformer(source);
-//				Source xmlSource = new StreamSource(inputFilename);
 				String outfileName = inputFilename + ".transformed.tsv";
-//				Result outputTarget =  new StreamResult(new File(outfileName));
-//				transformer.transform(xmlSource, outputTarget);
 				this.transformXmlToTsv(inputFilename, outfileName);
 				
 				//Now we need to read the file.
@@ -108,16 +103,6 @@ public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetaboli
 					hmdb2ChebiAndUniprot.put(parts[0], hmdbVals);
 				});
 			}
-//			catch (TransformerConfigurationException e)
-//			{
-//				e.printStackTrace();
-//				throw new Error(e);
-//			}
-//			catch (TransformerException e)
-//			{
-//				e.printStackTrace();
-//				throw new Error(e);
-//			}
 			catch (IOException e)
 			{
 				e.printStackTrace();

--- a/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
+++ b/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
@@ -160,27 +160,22 @@ public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetaboli
 		catch (FileNotFoundException e ) 
 		{
 			logger.error("Input XML file was not found!", e);
-			e.printStackTrace();
 		}
 		catch (XMLStreamException e)
 		{
 			logger.error("Error streaming XML file!", e);
-			e.printStackTrace();	
 		}
 		catch (TransformerConfigurationException e)
 		{
 			logger.error("Error with XSL file!", e);
-			e.printStackTrace();
 		}
 		catch (TransformerException e)
 		{
 			logger.error("Data transformation error!", e);
-			e.printStackTrace();
 		}
 		catch (IOException e)
 		{
 			logger.error("I/O Error", e);
-			e.printStackTrace();
 		}
 	}
 }

--- a/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
+++ b/src/main/java/org/reactome/addlinks/fileprocessors/HmdbMetabolitesFileProcessor.java
@@ -141,13 +141,17 @@ public class HmdbMetabolitesFileProcessor extends FileProcessor<Map<HmdbMetaboli
 			Source source = new StreamSource(this.getClass().getClassLoader().getResourceAsStream("hmdb_metabolites_transform.xsl"));
 			TransformerFactory factory = TransformerFactory.newInstance();
 			Transformer transformer = factory.newTransformer(source);
-			
+			// While there are start elements...
 			while (xsr.nextTag() == XMLStreamConstants.START_ELEMENT)
 			{
+				// Check if the current start element is "metabolite" - that's the root element that we will transform.
 				if (xsr.getName().getLocalPart().equals(METABOLITE_ELEMENT_NAME))
 				{
+					// Get everything rooted under the "metabolite" element.
 					StAXSource src = new StAXSource(xsr);
+					// get a Result that points to the output file 
 					Result result = new StreamResult(outStream);
+					// execute the XSL transform - the transformed output will go to the output file via `result`.
 					transformer.transform(src, result);
 				}
 			}

--- a/src/main/java/org/reactome/addlinks/fileprocessors/ensembl/EnsemblBioMartFileProcessor.java
+++ b/src/main/java/org/reactome/addlinks/fileprocessors/ensembl/EnsemblBioMartFileProcessor.java
@@ -89,7 +89,6 @@ public class EnsemblBioMartFileProcessor extends FileProcessor<Map<String, List<
                     // Get species name from filename
                     String biomartFileSpecies = bioMartFile.getFileName().toString().split("_")[0];
                     logger.info("Processing {}", bioMartFile.getFileName());
-//                    List<String> biomartFileLines = EnsemblBioMartUtil.getLinesFromFile(bioMartFile, false);
 
                     // Processing of UniProt mapping files.
                     // UniProt identifier mapping files are used to fully populate
@@ -137,31 +136,11 @@ public class EnsemblBioMartFileProcessor extends FileProcessor<Map<String, List<
      * adds one of the four values (Gene, Transcript, Protein, UniProt/Microarray/GO terms) as a key to a List of
      * one of the other four values. For example, if it was building 'TranscriptToOtherIdentifiers', the key is the
      * transcript identifier of the line while the value is a List of Microarray/GO term identifiers.
-     * @param biomartFileLines List<String> - All tab-separated lines from the current BioMart file being processed.
+     * @param bioMartFile Path - A Path to a biomart file.
      * @param keyIndex int - The column indice that will be used as a key.
      * @param valueIndex int - The column indice that will be used as a value.
      * @return Map<String, List<String>> - The completed mapping from the BioMart file being processed.
      */
-    private Map<String, List<String>> getIdentifierMapping(List<String> biomartFileLines, int keyIndex, int valueIndex) {
-
-        Map<String, List<String>> identifierMapping = new HashMap<>();
-        for (String biomartFileLine : biomartFileLines) {
-            // Split each tab-separated line. Each line has four values. The first three are always
-            // Ensembl Gene (ENSG), Transcript (ENST) and Protein (ENSP), in that order.
-            // The 4th can be a UniProt/Microarray/GO term identifier, depending on the file being read.
-            // None of the values are guaranteed to in the line except perhaps the first (Gene).
-            List<String> tabSplit = Arrays.asList(biomartFileLine.split("\t"));
-            if (properArraySizeAndNecessaryColumnsContainData(tabSplit, keyIndex, valueIndex)) {
-                String mapKey = tabSplit.get(keyIndex);
-                String mapValue = tabSplit.get(valueIndex);
-
-                identifierMapping.computeIfAbsent(mapKey, k -> new ArrayList<>()).add(mapValue);
-            }
-        }
-
-        return identifierMapping;
-    }
-    
     private Map<String, List<String>> getIdentifierMapping(Path bioMartFile, int keyIndex, int valueIndex)
     {
         Map<String, List<String>> identifierMapping = new HashMap<>();

--- a/src/main/java/org/reactome/addlinks/fileprocessors/ensembl/EnsemblBioMartFileProcessor.java
+++ b/src/main/java/org/reactome/addlinks/fileprocessors/ensembl/EnsemblBioMartFileProcessor.java
@@ -1,9 +1,12 @@
 package org.reactome.addlinks.fileprocessors.ensembl;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.LineIterator;
 import org.reactome.addlinks.EnsemblBioMartUtil;
 import org.reactome.addlinks.fileprocessors.FileProcessor;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -81,25 +84,25 @@ public class EnsemblBioMartFileProcessor extends FileProcessor<Map<String, List<
         Map<String, Map<String, List<String>>> mappings = new HashMap<>();
         // Read each file in BioMart directory and iterate through each line.
         try (Stream<Path> paths = Files.walk(this.pathToFile)) {
-            paths
-                .filter(Files::isRegularFile)
-                .forEach(bioMartFile -> {
+            paths.filter(Files::isRegularFile)
+                 .forEach(bioMartFile -> {
                     // Get species name from filename
                     String biomartFileSpecies = bioMartFile.getFileName().toString().split("_")[0];
-                    List<String> biomartFileLines = EnsemblBioMartUtil.getLinesFromFile(bioMartFile, false);
+                    logger.info("Processing {}", bioMartFile.getFileName());
+//                    List<String> biomartFileLines = EnsemblBioMartUtil.getLinesFromFile(bioMartFile, false);
 
                     // Processing of UniProt mapping files.
                     // UniProt identifier mapping files are used to fully populate
                     // the 'uniprotToProteins' and 'proteinToGenes' mappings.
                     if (bioMartFile.toString().endsWith(EnsemblBioMartUtil.UNIPROT_SUFFIX)) {
                         // 'uniprotToProteins' mapping requires the 3rd (protein) and 4th (uniprot) values in the line.
-                        Map<String, List<String>> uniprotToProteins = getIdentifierMapping(biomartFileLines, IDENTIFIER_INDEX, PROTEIN_IDENTIFIER_INDEX);
+                        Map<String, List<String>> uniprotToProteins = getIdentifierMapping(bioMartFile, IDENTIFIER_INDEX, PROTEIN_IDENTIFIER_INDEX);
                         if (!uniprotToProteins.isEmpty()) {
                             // Add each mapping generated to the 'super' mapping
                             mappings.put(biomartFileSpecies + EnsemblBioMartUtil.UNIPROT_TO_PROTEINS_SUFFIX, uniprotToProteins);
                         }
                         // 'proteinToGenes' mappings require the 1st (gene) and 3rd (protein) values in the line.
-                        Map<String, List<String>> proteinToGenes = getIdentifierMapping(biomartFileLines, PROTEIN_IDENTIFIER_INDEX, GENE_IDENTIFIER_INDEX);
+                        Map<String, List<String>> proteinToGenes = getIdentifierMapping(bioMartFile, PROTEIN_IDENTIFIER_INDEX, GENE_IDENTIFIER_INDEX);
                         if (!proteinToGenes.isEmpty()) {
                             // Add each mapping generated to the 'super' mapping
                             mappings.put(biomartFileSpecies + EnsemblBioMartUtil.PROTEIN_TO_GENES_SUFFIX, proteinToGenes);
@@ -109,13 +112,13 @@ public class EnsemblBioMartFileProcessor extends FileProcessor<Map<String, List<
                     // 'proteinToTranscripts' and 'transcriptToOtherIdentifiers' mappings.
                     } else if (bioMartFile.toString().endsWith(EnsemblBioMartUtil.MICROARRAY_IDS_AND_GO_TERMS_SUFFIX)) {
                         // 'proteinToTranscripts' mapping requires the 2nd (transcript) and 3rd (protein) values in the line.
-                        Map<String, List<String>> proteinToTranscripts = getIdentifierMapping(biomartFileLines, PROTEIN_IDENTIFIER_INDEX, TRANSCRIPT_IDENTIFIER_INDEX);
+                        Map<String, List<String>> proteinToTranscripts = getIdentifierMapping(bioMartFile, PROTEIN_IDENTIFIER_INDEX, TRANSCRIPT_IDENTIFIER_INDEX);
                         if (!proteinToTranscripts.isEmpty()) {
                             // Add each mapping generated to the 'super' mapping
                             mappings.put(biomartFileSpecies + EnsemblBioMartUtil.PROTEIN_TO_TRANSCRIPTS_SUFFIX, proteinToTranscripts);
                         }
                         // 'transcriptToOtherIdentifiers' mapping requires the 2nd (transcript) and 4th (microarray/GO term) values in the line.
-                        Map<String, List<String>> transcriptToOtherIdentifiers = getIdentifierMapping(biomartFileLines, TRANSCRIPT_IDENTIFIER_INDEX, IDENTIFIER_INDEX);
+                        Map<String, List<String>> transcriptToOtherIdentifiers = getIdentifierMapping(bioMartFile, TRANSCRIPT_IDENTIFIER_INDEX, IDENTIFIER_INDEX);
                         if (!transcriptToOtherIdentifiers.isEmpty()) {
                             // Add each mapping generated to the 'super' mapping
                             mappings.put(biomartFileSpecies + EnsemblBioMartUtil.TRANSCRIPT_TO_OTHER_IDENTIFIERS_SUFFIX, transcriptToOtherIdentifiers);
@@ -156,6 +159,34 @@ public class EnsemblBioMartFileProcessor extends FileProcessor<Map<String, List<
             }
         }
 
+        return identifierMapping;
+    }
+    
+    private Map<String, List<String>> getIdentifierMapping(Path bioMartFile, int keyIndex, int valueIndex)
+    {
+        Map<String, List<String>> identifierMapping = new HashMap<>();
+        try
+        {
+            LineIterator iterator = FileUtils.lineIterator(bioMartFile.toFile(), StandardCharsets.ISO_8859_1.toString());
+            
+            while (iterator.hasNext())
+            {
+                String line = iterator.nextLine();
+                List<String> tabSplit = Arrays.asList(line.split("\t"));
+                if (properArraySizeAndNecessaryColumnsContainData(tabSplit, keyIndex, valueIndex))
+                {
+                    String mapKey = tabSplit.get(keyIndex);
+                    String mapValue = tabSplit.get(valueIndex);
+                    identifierMapping.computeIfAbsent(mapKey, k -> new ArrayList<>()).add(mapValue);
+                }
+            }
+        }
+        catch (IOException e)
+        {
+            logger.error("I/O Error with file: " + bioMartFile.toString(), e);
+            e.printStackTrace();
+        }
+        
         return identifierMapping;
     }
 

--- a/src/main/java/org/reactome/addlinks/referencecreators/EnsemblBioMartOtherIdentifierPopulator.java
+++ b/src/main/java/org/reactome/addlinks/referencecreators/EnsemblBioMartOtherIdentifierPopulator.java
@@ -73,21 +73,19 @@ public class EnsemblBioMartOtherIdentifierPopulator extends SimpleReferenceCreat
         Set<String> rgpProteins = findRGPProteins(rgpInst, speciesBiomartName, mappings);
         // For each protein identifier retrieved, find OtherIdentifiers associated with it and
         // add them to the 'otherIdentifier' attribute of the RGP instance.
+        Set<String> otherIdentifiers = new TreeSet<>(rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier));
         for (String protein : rgpProteins) {
             // This check is required since the identifier taken from the RGP may not have a key in the proteinToTranscript mapping.
             Map<String, List<String>> proteinToTranscripts = EnsemblBioMartUtil.getProteinToTranscriptsMappings(speciesBiomartName, mappings);
             for (String transcript : proteinToTranscripts.computeIfAbsent(protein, k -> new ArrayList<>())) {
-
-                Set<String> otherIdentifiers = new HashSet<>(rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier));
                 Map<String, List<String>> transcriptToOtherIdentifiers = EnsemblBioMartUtil.getTranscriptToOtherIdentifiersMappings(speciesBiomartName, mappings);
                 for (String newOtherIdentifier : transcriptToOtherIdentifiers.computeIfAbsent(transcript, k -> new ArrayList<>())) {
                     otherIdentifiers.add(newOtherIdentifier);
                 }
-
-                if (!EnsemblBioMartOtherIdentifierPopulator.this.testMode) {
-                        rgpInst.setAttributeValue(ReactomeJavaConstants.otherIdentifier, new ArrayList<>(otherIdentifiers));
-                }
             }
+        }
+        if (!EnsemblBioMartOtherIdentifierPopulator.this.testMode) {
+            rgpInst.setAttributeValue(ReactomeJavaConstants.otherIdentifier, new ArrayList<>(otherIdentifiers));
         }
         sortOtherIdentifiersAndUpdateInstance(rgpInst);
     }
@@ -133,8 +131,8 @@ public class EnsemblBioMartOtherIdentifierPopulator extends SimpleReferenceCreat
 
     // Sorts all microarray/GO term values added to otherIdentifier slot and updates instance with new data.
     private void sortOtherIdentifiersAndUpdateInstance(GKInstance rgpInst) throws Exception {
-        List<String> otherIdentifiers = rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier);
-        Collections.sort(otherIdentifiers);
+//        List<String> otherIdentifiers = rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier);
+//        Collections.sort(otherIdentifiers);
         updateInstance(rgpInst);
 
     }

--- a/src/main/java/org/reactome/addlinks/referencecreators/EnsemblBioMartOtherIdentifierPopulator.java
+++ b/src/main/java/org/reactome/addlinks/referencecreators/EnsemblBioMartOtherIdentifierPopulator.java
@@ -73,6 +73,7 @@ public class EnsemblBioMartOtherIdentifierPopulator extends SimpleReferenceCreat
         Set<String> rgpProteins = findRGPProteins(rgpInst, speciesBiomartName, mappings);
         // For each protein identifier retrieved, find OtherIdentifiers associated with it and
         // add them to the 'otherIdentifier' attribute of the RGP instance.
+        // TreeSet ensures the the identifiers will stay sorted.
         Set<String> otherIdentifiers = new TreeSet<>(rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier));
         for (String protein : rgpProteins) {
             // This check is required since the identifier taken from the RGP may not have a key in the proteinToTranscript mapping.
@@ -84,10 +85,12 @@ public class EnsemblBioMartOtherIdentifierPopulator extends SimpleReferenceCreat
                 }
             }
         }
+        // Now that the set has been fully populated, set the attribute and update instance.
         if (!EnsemblBioMartOtherIdentifierPopulator.this.testMode) {
             rgpInst.setAttributeValue(ReactomeJavaConstants.otherIdentifier, new ArrayList<>(otherIdentifiers));
+            adapter.updateInstanceAttribute(rgpInst, ReactomeJavaConstants.otherIdentifier);
         }
-        sortOtherIdentifiersAndUpdateInstance(rgpInst);
+//        sortOtherIdentifiersAndUpdateInstance(rgpInst);
     }
 
     /**
@@ -130,17 +133,17 @@ public class EnsemblBioMartOtherIdentifierPopulator extends SimpleReferenceCreat
     }
 
     // Sorts all microarray/GO term values added to otherIdentifier slot and updates instance with new data.
-    private void sortOtherIdentifiersAndUpdateInstance(GKInstance rgpInst) throws Exception {
-//        List<String> otherIdentifiers = rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier);
-//        Collections.sort(otherIdentifiers);
-        updateInstance(rgpInst);
-
-    }
+//    private void sortOtherIdentifiersAndUpdateInstance(GKInstance rgpInst) throws Exception {
+////        List<String> otherIdentifiers = rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier);
+////        Collections.sort(otherIdentifiers);
+//        updateInstance(rgpInst);
+//
+//    }
 
     // Updates the OtherIdentifier attribute of the ReferenceGeneProduct with Microarray/GO term data in the database.
-    private void updateInstance(GKInstance rgpInst) throws Exception {
-        adapter.updateInstanceAttribute(rgpInst, ReactomeJavaConstants.otherIdentifier);
-    }
+//    private void updateInstance(GKInstance rgpInst) throws Exception {
+//        adapter.updateInstanceAttribute(rgpInst, ReactomeJavaConstants.otherIdentifier);
+//    }
 
     // Checks that none of the provided mapping structures are null.
     public boolean allDataStructuresPopulated(Map<String, List<String>> proteinToTranscripts, Map<String, List<String>> transcriptToOtherIdentifiers, Map<String, List<String>> uniprotToProtein) {

--- a/src/main/java/org/reactome/addlinks/referencecreators/EnsemblBioMartOtherIdentifierPopulator.java
+++ b/src/main/java/org/reactome/addlinks/referencecreators/EnsemblBioMartOtherIdentifierPopulator.java
@@ -85,12 +85,11 @@ public class EnsemblBioMartOtherIdentifierPopulator extends SimpleReferenceCreat
                 }
             }
         }
-        // Now that the set has been fully populated, set the attribute and update instance.
+        // Now that the set has been populated, set the attribute and update instance.
         if (!EnsemblBioMartOtherIdentifierPopulator.this.testMode) {
             rgpInst.setAttributeValue(ReactomeJavaConstants.otherIdentifier, new ArrayList<>(otherIdentifiers));
             adapter.updateInstanceAttribute(rgpInst, ReactomeJavaConstants.otherIdentifier);
         }
-//        sortOtherIdentifiersAndUpdateInstance(rgpInst);
     }
 
     /**
@@ -131,19 +130,6 @@ public class EnsemblBioMartOtherIdentifierPopulator extends SimpleReferenceCreat
         }
         return rgpIdentifiersToRGPs;
     }
-
-    // Sorts all microarray/GO term values added to otherIdentifier slot and updates instance with new data.
-//    private void sortOtherIdentifiersAndUpdateInstance(GKInstance rgpInst) throws Exception {
-////        List<String> otherIdentifiers = rgpInst.getAttributeValuesList(ReactomeJavaConstants.otherIdentifier);
-////        Collections.sort(otherIdentifiers);
-//        updateInstance(rgpInst);
-//
-//    }
-
-    // Updates the OtherIdentifier attribute of the ReferenceGeneProduct with Microarray/GO term data in the database.
-//    private void updateInstance(GKInstance rgpInst) throws Exception {
-//        adapter.updateInstanceAttribute(rgpInst, ReactomeJavaConstants.otherIdentifier);
-//    }
 
     // Checks that none of the provided mapping structures are null.
     public boolean allDataStructuresPopulated(Map<String, List<String>> proteinToTranscripts, Map<String, List<String>> transcriptToOtherIdentifiers, Map<String, List<String>> uniprotToProtein) {

--- a/src/main/resources/hmdb_metabolites_transform.xsl
+++ b/src/main/resources/hmdb_metabolites_transform.xsl
@@ -5,7 +5,7 @@
 	<!-- Produce a TSV of HMDB accessions followed by a UniProt ID -->
 
 	<!-- Match any metabolite -->
-	<xsl:template match="/hmdb:hmdb/hmdb:metabolite/hmdb:accession" >
+	<xsl:template match="/hmdb:metabolite/hmdb:accession" >
 		<xsl:value-of select="./text()" />
  		<xsl:text>&#x9;</xsl:text>
 		<xsl:value-of select="../hmdb:chebi_id/text()"/>


### PR DESCRIPTION
Fixes some memory-related issues:
 - Transform HMDB Metabolites XML file in chunks, rather than attempt to transform the whole file at once.
 - Fixed Ensembl Biomart file processor to process files line-by-line rather than trying to use `readAllLines`
 - some other tweaks and fixes.