### PR TITLE
Feature/add target pathogen to contexts

### DIFF
--- a/src/main/resources/create-references-context.xml
+++ b/src/main/resources/create-references-context.xml
@@ -44,6 +44,7 @@
 	</util:list>
 
 	<util:list id="fileProcessorFilter" value-type="java.lang.String">
+		<value>TargetPathogenFileProcessor</value>
 		<value>IntEnzFileProcessor</value>
 		<value>ENSEMBLFileProcessor</value>
 		<value>ENSEMBLNonCoreFileProcessor</value>
@@ -81,6 +82,8 @@
 	</util:list>
 
 	<util:list id="referenceCreatorFilter" value-type="java.lang.String">
+		<value>TargetPathogenReactionsReferenceCreator</value>
+		<value>TargetPathogenProteinsReferenceCreator</value>
 		<value>IntEnzRefCreator</value>		
 		<value>ENSEMBLToEntrezGeneRefCreator</value>
 		<value>ENSEMBLEnspToEnsgRefCreator</value>
@@ -126,6 +129,7 @@
 	</util:list>
 	
 	<util:list id="referenceDatabasesToLinkCheck" value-type="java.lang.String">
+		<value>Target Pathogen</value>
 		<value>IntEnz</value>
 		<value>ENSEMBL</value>
 		<value>PDB</value>

--- a/src/main/resources/file-download-context.xml
+++ b/src/main/resources/file-download-context.xml
@@ -40,6 +40,7 @@
 	
 
 	<util:list id="fileRetrieverFilter" value-type="java.lang.String">
+		<value>TargetPathogen</value>
 		<value>IntEnz</value>		
 		<value>UniProtToENSEMBL</value>
 		<value>EnsemblToALL</value>


### PR DESCRIPTION
TargetPathogen information didn't exist in the file-download-context or create-reference-context files, only in the aggregate application-context