### PR TITLE
Feature/update cosmic url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/reactome/addlinks/dataretrieval/FileRetriever.java
+++ b/src/main/java/org/reactome/addlinks/dataretrieval/FileRetriever.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.SocketException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -231,7 +232,8 @@ public class FileRetriever implements DataRetriever {
 		while(!done)
 		{
 			try( CloseableHttpClient client = HttpClients.createDefault();
-				CloseableHttpResponse response = client.execute(get, context) )
+				CloseableHttpResponse response = client.execute(get, context);
+				OutputStream outputFile = new FileOutputStream(path.toFile()))
 			{
 				int statusCode = response.getStatusLine().getStatusCode();
 				// If status code was not 200, we should print something so that the users know that an unexpected response was received.
@@ -246,8 +248,7 @@ public class FileRetriever implements DataRetriever {
 						logger.warn("Response was not \"200\". It was: {}", response.getStatusLine());
 					}
 				}
-					
-				Files.write(path, EntityUtils.toByteArray(response.getEntity()));
+				response.getEntity().writeTo(outputFile);
 				done = true;
 			}
 			catch (ConnectTimeoutException e)

--- a/src/main/java/org/reactome/addlinks/fileprocessors/COSMICFileProcessor.java
+++ b/src/main/java/org/reactome/addlinks/fileprocessors/COSMICFileProcessor.java
@@ -1,11 +1,13 @@
 package org.reactome.addlinks.fileprocessors;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 public class COSMICFileProcessor extends FileProcessor<String>
 {
@@ -23,17 +25,23 @@ public class COSMICFileProcessor extends FileProcessor<String>
 	@Override
 	public Map<String, String> getIdMappingsFromFile()
 	{
-		Map<String,String> mappings = new HashMap<String, String>();
+		Map<String,String> mappings = new ConcurrentHashMap<>();
 		try
 		{
 			String unzippedFile = this.unzipFile(this.pathToFile);
 			AtomicInteger lineCount = new AtomicInteger(0);
-			try
+
+			try(Stream<String> lineStream = Files.lines(Paths.get(unzippedFile), StandardCharsets.ISO_8859_1))
 			{
-				//I added ".sequential()" because I have line counter and I want to ensure that it works properly.
-				Files.lines(Paths.get(unzippedFile)).filter(p -> !p.startsWith("#")).sequential().forEach( line ->
+				// Use parallel streams at your own peril! I kept running out of RAM and
+				// crashing on my OICR laptop - the server or the office-based workstation can
+				// *probably* handle it but since I can't successfully test, I will leave this
+				// as a sequential stream, for now. But honestly, it took my laptop ~7 minutes
+				// to process the file. I can't imagine a parallel stream would save more
+				// than 3 or 4 minutes...
+				lineStream.filter(p -> !p.startsWith("#")).sequential().forEach( line ->
 				{
-					lineCount.set(lineCount.get() + 1);
+					lineCount.incrementAndGet();
 					String[] parts = line.split("\\t");
 					if (parts.length > 0)
 					{

--- a/src/main/resources/basic-file-retrievers.xml
+++ b/src/main/resources/basic-file-retrievers.xml
@@ -166,7 +166,7 @@
 			<bean class="org.reactome.addlinks.dataretrieval.COSMICFileRetriever" id="COSMIC">
 				<property name="userName" value="${cosmic.user}"/>
 				<property name="password" value="${cosmic.password}"/>
-				<property name="dataURL" value="https://cancer.sanger.ac.uk/cosmic/file_download/GRCh38/cosmic/v87/CosmicMutantExport.tsv.gz" />
+				<property name="dataURL" value="https://cancer.sanger.ac.uk/cosmic/file_download/GRCh38/cosmic/v92/CosmicMutantExport.tsv.gz" />
 				<property name="fetchDestination" value="/tmp/addlinks-downloaded-files/CosmicMutantExport.tsv.gz" />
 				<property name="maxAge" ref="maxFileAge" />
 				<constructor-arg name="retrieverName" value="retrievers/COSMIC"/>


### PR DESCRIPTION
Download a newer COSMIC file, and some code changes to support it:

 - file is too big to be buffered in memory so write to output stream when downloading
 - specify character set for file

Minor, unrelated change:
 - upgrade JUnit dependency from 4.12 to 4.13.1 b/c of dependabot's nagging. Ran some JUnit tests, they still run fine.