### PR TITLE
Actually delete /tmp/addlinks-downloaded-files folder after completion of step

### DIFF
--- a/Jenkinsfile-downloads
+++ b/Jenkinsfile-downloads
@@ -97,7 +97,7 @@ pipeline{
 					
 					def dataFiles = ["/tmp/$downloadsArchive"]
 					def logFiles = ["reports/*"]
-					def foldersToDelete = ["reports", "/tmp/$downloadsArchive", "$addlinksFolder"]
+					def foldersToDelete = ["reports", "/tmp/$addlinksFolder"]
 					
 					sh "cd /tmp/; tar -zcvf $downloadsArchive $addlinksFolder"
 					utils.cleanUpAndArchiveBuildFiles("add_links/downloads", dataFiles, logFiles, foldersToDelete)


### PR DESCRIPTION
Very small update - the /tmp/addlinks-downloaded-files folder was being archived on S3 by Jenkins, but then it wasn't being deleted, which is incorrect behaviour