### PR TITLE
R76 tweaks

### DIFF
--- a/src/main/java/org/reactome/addlinks/kegg/KEGGReferenceDatabaseGenerator.java
+++ b/src/main/java/org/reactome/addlinks/kegg/KEGGReferenceDatabaseGenerator.java
@@ -40,7 +40,7 @@ public class KEGGReferenceDatabaseGenerator
 		KEGGReferenceDatabaseGenerator.dbCreator = creator;
 	}
 
-	private static Long createReferenceDatabase(String dbName, String speciesName, String speciesURL, ReferenceObjectCache objectCache) throws Exception
+	private static synchronized Long createReferenceDatabase(String dbName, String speciesName, String speciesURL, ReferenceObjectCache objectCache) throws Exception
 	{
 		if (objectCache.getRefDbNamesToIds().keySet().contains(dbName))
 		{
@@ -69,7 +69,7 @@ public class KEGGReferenceDatabaseGenerator
 	 * Generate new species-specific KEGG reference databases. The new database will be named in the form "KEGG Gene (${SPECIES_NAME})".
 	 * @param objectCache - The object cache. The list of species in this cache will be what the new reference databases are based on.
 	 */
-	public static void generateSpeciesSpecificReferenceDatabases(ReferenceObjectCache objectCache)
+	public static synchronized void generateSpeciesSpecificReferenceDatabases(ReferenceObjectCache objectCache)
 	{
 		for (String speciesName : objectCache.getSpeciesNamesToIds().keySet())
 		{
@@ -139,7 +139,7 @@ public class KEGGReferenceDatabaseGenerator
 	 * @param keggSpeciesCode KEGG species code.
 	 * @return The DBID of the KEGG ReferenceDatabase object, if it exists. If no ReferenceDatabase can be found (or too many matching ReferenceDatabases), then NULL will be returned.
 	 */
-	public static Long getKeggReferenceDatabase(String keggSpeciesCode)
+	public static synchronized Long getKeggReferenceDatabase(String keggSpeciesCode)
 	{
 		Long dbId = null;
 		if (KEGGReferenceDatabaseGenerator.keggCodesToRefDBMap.containsKey(keggSpeciesCode))
@@ -162,7 +162,7 @@ public class KEGGReferenceDatabaseGenerator
 					// And we will add to the cache since it wasn't there.
 					KEGGReferenceDatabaseGenerator.keggCodesToRefDBMap.put(keggSpeciesCode, refDB);
 				}
-				else if (refDBs.size() == 0)
+				else if (refDBs.isEmpty())
 				{
 					logger.error("Sorry, there was no KEGG ReferenceDatabase with the KEGG species code {}", keggSpeciesCode);
 				}
@@ -245,7 +245,7 @@ public class KEGGReferenceDatabaseGenerator
 		String speciesURL = KEGG_URL.replace("###SP3###", keggPrefix + ":");
 		try
 		{
-			Long dbId = new Long(createReferenceDatabase(newDBName, keggSpeciesName, speciesURL, objectCache));
+			Long dbId = createReferenceDatabase(newDBName, keggSpeciesName, speciesURL, objectCache);
 			GKInstance refDBInst = adaptor.fetchInstance(dbId);
 			KEGGReferenceDatabaseGenerator.keggCodesToRefDBMap.put(keggPrefix, refDBInst);
 			return dbId.toString();

--- a/src/main/java/org/reactome/addlinks/kegg/KEGGSpeciesCache.java
+++ b/src/main/java/org/reactome/addlinks/kegg/KEGGSpeciesCache.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,9 +104,19 @@ public final class KEGGSpeciesCache
 						// or summary/group headings.
 						logger.trace("Line/pattern mismatch: {}",line);
 					}
-
 				}
-				logger.info("{} keys added to the KEGG species map.",KEGGSpeciesCache.speciesMap.keySet().size());
+				// Add vg for Virus, and ag for Addendum - they are not in the KEGG species list, but are still valid prefixes.
+				codesToSpecies.put("vg", "Virus");
+				codesToSpecies.put("ag", "Addendum");
+				HashMap<String, String> virusMap = new HashMap<>();
+				virusMap.put(KEGG_CODE, "vg");
+				virusMap.put(COMMON_NAME, "");
+				speciesMap.put("Virus", Arrays.asList(virusMap));
+				HashMap<String, String> addendumMap = new HashMap<>();
+				addendumMap.put(KEGG_CODE, "ag");
+				addendumMap.put(COMMON_NAME, "");
+				speciesMap.put("Addendum", Arrays.asList(addendumMap));
+				logger.info("{} keys added to the KEGG species map.", KEGGSpeciesCache.speciesMap.keySet().size());
 			}
 		}
 		catch (URISyntaxException | IOException e)
@@ -188,6 +199,10 @@ public final class KEGGSpeciesCache
 			if (KEGGSpeciesCache.getKeggSpeciesCodes().contains(prefix))
 			{
 				return prefix;
+			}
+			else
+			{
+				logger.warn("Could not extract a KEGG species prefix from identifier: \"{}\". Maybe check the KEGG species list?", identifier);
 			}
 		}
 		return null;

--- a/src/main/java/org/reactome/addlinks/kegg/KEGGSpeciesCache.java
+++ b/src/main/java/org/reactome/addlinks/kegg/KEGGSpeciesCache.java
@@ -108,11 +108,11 @@ public final class KEGGSpeciesCache
 				// Add vg for Virus, and ag for Addendum - they are not in the KEGG species list, but are still valid prefixes.
 				codesToSpecies.put("vg", "Virus");
 				codesToSpecies.put("ag", "Addendum");
-				HashMap<String, String> virusMap = new HashMap<>();
+				Map<String, String> virusMap = new HashMap<>();
 				virusMap.put(KEGG_CODE, "vg");
 				virusMap.put(COMMON_NAME, "");
 				speciesMap.put("Virus", Arrays.asList(virusMap));
-				HashMap<String, String> addendumMap = new HashMap<>();
+				Map<String, String> addendumMap = new HashMap<>();
 				addendumMap.put(KEGG_CODE, "ag");
 				addendumMap.put(COMMON_NAME, "");
 				speciesMap.put("Addendum", Arrays.asList(addendumMap));

--- a/src/main/java/org/reactome/addlinks/referencecreators/KEGGReferenceCreatorHelper.java
+++ b/src/main/java/org/reactome/addlinks/referencecreators/KEGGReferenceCreatorHelper.java
@@ -91,7 +91,7 @@ class KEGGReferenceCreatorHelper
 			// So, we can't add the cross-reference since we don't know which species-specific ReferenceDatabase to use.
 			if (targetDB == null)
 			{
-				this.logger.warn("No KEGG DB Name could be obtained for this identifier: {}. The next step is to try to create a *new* ReferenceDatabase.", identifier);
+				this.logger.warn("No KEGG DB Name could be obtained for this identifier: {} with this prefix: {}. The next step is to try to create a *new* ReferenceDatabase.", identifier, keggPrefix);
 
 				if (keggPrefix != null)
 				{

--- a/src/main/java/org/reactome/addlinks/referencecreators/KEGGReferenceCreatorHelper.java
+++ b/src/main/java/org/reactome/addlinks/referencecreators/KEGGReferenceCreatorHelper.java
@@ -68,8 +68,8 @@ class KEGGReferenceCreatorHelper
 	{
 		String identifier = keggIdentifier;
 		String targetDB = null;
-		// "vg:" and "ad:" aren't in the species list because they are not actually species. So that's why it's OK to check for them here, after
-		// the identifier has already been pruned.
+		// "vg:" and "ag:" aren't in the species list because they are not actually species. So that's why it's OK to check for them here, after
+		// the identifier has already been pruned. Virus: https://www.genome.jp/dbget-bin/www_bfind?vg ; Addendum: https://www.genome.jp/dbget-bin/www_bfind?ag
 		if (identifier.startsWith("vg:"))
 		{
 			targetDB = "KEGG Gene (Viruses)";

--- a/src/main/java/org/reactome/addlinks/referencecreators/UPMappedIdentifiersReferenceCreator.java
+++ b/src/main/java/org/reactome/addlinks/referencecreators/UPMappedIdentifiersReferenceCreator.java
@@ -166,8 +166,12 @@ public class UPMappedIdentifiersReferenceCreator extends NCBIGeneBasedReferenceC
 									{
 										targetDB = setTargetDBForENSEMBL(generateENSEMBLRefDBName, speciesID);
 									}
-									if (!targetIsKEGG || !forbiddenKEGGPrefix)
+									if (!targetIsKEGG || !forbiddenKEGGPrefix) // If target is NOT kegg ...OR... if kegg prefix is NOT forbidden...
 									{
+										if (targetDB == null || targetDB.trim().equals("") || targetDB.equalsIgnoreCase("null"))
+										{
+											logger.error("Got a NULL targetDB for targetIdentifier: {}, sourceIdentifier: {}", targetIdentifier, sourceIdentifier);
+										}
 										boolean xrefAlreadyExists = checkXRefExists(inst, targetIdentifier, targetDB);
 										String thingToCreate = targetIdentifier+","+String.valueOf(inst.getDBID())+","+speciesID+","+targetDB;
 										if (!xrefAlreadyExists && !thingsToCreate.contains(thingToCreate) && targetDB != null)

--- a/src/main/resources/create-references-context.xml
+++ b/src/main/resources/create-references-context.xml
@@ -44,6 +44,7 @@
 	</util:list>
 
 	<util:list id="fileProcessorFilter" value-type="java.lang.String">
+		<!-- <value>UniprotToKEGGFileProcessor</value>
 		<value>PharmacoDBFileProcessor</value>
 		<value>TargetPathogenFileProcessor</value>
 		<value>IntEnzFileProcessor</value>
@@ -65,7 +66,6 @@
 		<value>HGNCProcessor</value>
 		<value>zincOrthologFileProcessor</value>
 		<value>KEGGFileProcessor</value>
-		<value>UniprotToKEGGFileProcessor</value>
 		<value>zincProtFileProcessor</value>
 		<value>RheaFileProcessor</value>
 		<value>HmdbProteinsFileProcessor</value>
@@ -81,11 +81,11 @@
 		<value>RGDFileProcessor</value>	
 		<value>XenbaseFileProcessor</value>
 		<value>ZFINFileProcessor</value>
-		<value>EnsemblBioMartFileProcessor</value>
+		<value>EnsemblBioMartFileProcessor</value> -->
 	</util:list>
 
 	<util:list id="referenceCreatorFilter" value-type="java.lang.String">
-		<value>upMappedKEGGRefCreator</value>
+		<!-- <value>upMappedKEGGRefCreator</value>
 		<value>PharmacoDBReferenceCreator</value>
 		<value>KEGGReferenceCreator</value>
 		<value>TargetPathogenReactionsReferenceCreator</value>
@@ -117,7 +117,6 @@
 		<value>zincToUniProtReferenceCreator</value>
 		<value>zincToChEBIReferenceCreator</value>
 		<value>HGNCReferenceCreator</value>
-		
 		<value>RheaReferenceCreator</value>
 		<value>OrphanetReferenceCreator</value>
 		<value>HMDBProtReferenceCreator</value>
@@ -132,7 +131,7 @@
 		<value>XenbaseFileProcessor</value>
 		<value>ZFINFileProcessor</value>
 		<value>EnsemblReferenceCreator</value>
-		<value>EnsemblBioMartOtherIdentifierPopulator</value>
+		<value>EnsemblBioMartOtherIdentifierPopulator</value> -->
 	</util:list>
 	
 	<util:list id="referenceDatabasesToLinkCheck" value-type="java.lang.String">

--- a/src/main/resources/create-references-context.xml
+++ b/src/main/resources/create-references-context.xml
@@ -86,6 +86,7 @@
 
 	<util:list id="referenceCreatorFilter" value-type="java.lang.String">
 		<value>PharmacoDBReferenceCreator</value>
+		<value>KEGGReferenceCreator</value>
 		<value>TargetPathogenReactionsReferenceCreator</value>
 		<value>TargetPathogenProteinsReferenceCreator</value>
 		<value>IntEnzRefCreator</value>
@@ -116,7 +117,6 @@
 		<value>zincToChEBIReferenceCreator</value>
 		<value>HGNCReferenceCreator</value>
 		<value>upMappedKEGGRefCreator</value>
-		<value>KEGGReferenceCreator</value>
 		<value>RheaReferenceCreator</value>
 		<value>OrphanetReferenceCreator</value>
 		<value>HMDBProtReferenceCreator</value>

--- a/src/main/resources/create-references-context.xml
+++ b/src/main/resources/create-references-context.xml
@@ -85,6 +85,7 @@
 	</util:list>
 
 	<util:list id="referenceCreatorFilter" value-type="java.lang.String">
+		<value>upMappedKEGGRefCreator</value>
 		<value>PharmacoDBReferenceCreator</value>
 		<value>KEGGReferenceCreator</value>
 		<value>TargetPathogenReactionsReferenceCreator</value>
@@ -116,7 +117,7 @@
 		<value>zincToUniProtReferenceCreator</value>
 		<value>zincToChEBIReferenceCreator</value>
 		<value>HGNCReferenceCreator</value>
-		<value>upMappedKEGGRefCreator</value>
+		
 		<value>RheaReferenceCreator</value>
 		<value>OrphanetReferenceCreator</value>
 		<value>HMDBProtReferenceCreator</value>

--- a/src/main/resources/create-references-context.xml
+++ b/src/main/resources/create-references-context.xml
@@ -44,7 +44,7 @@
 	</util:list>
 
 	<util:list id="fileProcessorFilter" value-type="java.lang.String">
-		<!-- <value>UniprotToKEGGFileProcessor</value>
+		<value>UniprotToKEGGFileProcessor</value>
 		<value>PharmacoDBFileProcessor</value>
 		<value>TargetPathogenFileProcessor</value>
 		<value>IntEnzFileProcessor</value>
@@ -81,11 +81,11 @@
 		<value>RGDFileProcessor</value>	
 		<value>XenbaseFileProcessor</value>
 		<value>ZFINFileProcessor</value>
-		<value>EnsemblBioMartFileProcessor</value> -->
+		<value>EnsemblBioMartFileProcessor</value>
 	</util:list>
 
 	<util:list id="referenceCreatorFilter" value-type="java.lang.String">
-		<!-- <value>upMappedKEGGRefCreator</value>
+		<value>upMappedKEGGRefCreator</value>
 		<value>PharmacoDBReferenceCreator</value>
 		<value>KEGGReferenceCreator</value>
 		<value>TargetPathogenReactionsReferenceCreator</value>
@@ -131,7 +131,7 @@
 		<value>XenbaseFileProcessor</value>
 		<value>ZFINFileProcessor</value>
 		<value>EnsemblReferenceCreator</value>
-		<value>EnsemblBioMartOtherIdentifierPopulator</value> -->
+		<value>EnsemblBioMartOtherIdentifierPopulator</value>
 	</util:list>
 	
 	<util:list id="referenceDatabasesToLinkCheck" value-type="java.lang.String">

--- a/src/main/resources/file-download-context.xml
+++ b/src/main/resources/file-download-context.xml
@@ -41,7 +41,7 @@
 
 	<util:list id="fileRetrieverFilter" value-type="java.lang.String">
 		<value>COSMIC</value>
-<!--		<value>IntEnz</value>
+		<value>IntEnz</value>
 		<value>TargetPathogen</value>
 		<value>UniProtToKEGG</value>
 		<value>UniProtToENSEMBL</value>
@@ -79,7 +79,7 @@
 		<value>RGD</value>
 		<value>Xenbase</value>
 		<value>ZFIN</value>
-		<value>EnsemblBioMart</value> -->
+		<value>EnsemblBioMart</value>
 	</util:list>
 
 	<util:list id="fileProcessorFilter" value-type="java.lang.String">

--- a/src/main/resources/file-download-context.xml
+++ b/src/main/resources/file-download-context.xml
@@ -8,11 +8,11 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder location="file:resources/*.properties"  />
-	
+
 <!-- 	<context:annotation-config/>
-	
+
 	<context:component-scan base-package="org.reactome.addlinks" annotation-config="true" />
- -->	
+ -->
 	<import resource="reference-databases.xml"/>
 	<import resource="basic-file-retrievers.xml"/>
 	<import resource="uniprot-file-retrievers.xml"/>
@@ -21,7 +21,7 @@
 	<import resource="file-processors-ref-creators-link.xml"/>
 	<import resource="reference-creators.xml"/>
 
-	<!-- DB Adapter 
+	<!-- DB Adapter
 	public MySQLAdaptor(String host,String database,String username,String password,int port)
 	-->
 	<bean id="dbAdapter" name="dbAdapter" class="org.gk.persistence.MySQLAdaptor" scope="singleton">
@@ -31,20 +31,21 @@
 		<constructor-arg name="password" index="3" value="${release.database.password}"/>
 		<constructor-arg name="port" index="4" value="${release.database.port}"/>
 	</bean>
-	
-	
+
+
 	<bean id="objectCache" class="org.reactome.addlinks.db.ReferenceObjectCache" scope="singleton">
 		<constructor-arg index="0" type="org.gk.persistence.MySQLAdaptor" name="adapter" ref="dbAdapter"/>
 		<constructor-arg index="1" type="boolean" name="lazyLoad" value="${lazyLoadCache}" />
 	</bean>
-	
+
 
 	<util:list id="fileRetrieverFilter" value-type="java.lang.String">
-		<value>UniProtToKEGG</value>
-		<value>KEGGRetriever</value>
+		<value>COSMIC</value>
+<!--		<value>IntEnz</value>
 		<value>TargetPathogen</value>
-		<value>IntEnz</value>		
+		<value>UniProtToKEGG</value>
 		<value>UniProtToENSEMBL</value>
+		<value>KEGGRetriever</value>
 		<value>EnsemblToALL</value>
 		<value>OpenTargets</value>
 		<value>FlyBaseToUniprotReferenceDNASequence</value>
@@ -58,7 +59,6 @@
 		<value>UniProtToOMIM</value>
 		<value>PROToReferencePeptideSequence</value>
 		<value>Zinc</value>
-		<value>COSMIC</value>
 		<value>HGNC</value>
 		<value>OrthologsFromZinc</value>
 		<value>OrthologsCSVFromZinc</value>
@@ -79,19 +79,19 @@
 		<value>RGD</value>
 		<value>Xenbase</value>
 		<value>ZFIN</value>
-		<value>EnsemblBioMart</value>
+		<value>EnsemblBioMart</value> -->
 	</util:list>
 
 	<util:list id="fileProcessorFilter" value-type="java.lang.String">
-		 
+
 	</util:list>
 
 	<util:list id="referenceCreatorFilter" value-type="java.lang.String">
-		 
+
 	</util:list>
-	
+
 	<util:list id="referenceDatabasesToLinkCheck" value-type="java.lang.String">
-		
+
 	</util:list>
 
 	<bean id="addLinks" name="addLinks" class="org.reactome.addlinks.AddLinks" scope="singleton" autowire="byName"
@@ -103,6 +103,6 @@
 		<property name="proportionToLinkCheck" value="${proportionToLinkCheck}"/>
 		<property name="maxNumberLinksToCheck" value="${maxNumberLinksToCheck}"/>
 	</bean>
-	
-	
+
+
 </beans>


### PR DESCRIPTION
Quick fixes to ensure that KEGG "vg" (virus) and ag ("addendum") database prefixes are in the KEGG species cache.

When running the UniProt-mapped-to-KEGG reference creation process, it failed with "vg:"-prefixed identifiers because "vg" was not in the KEGG species cached. I assume that this error was not noticed before because we did not get "vg"-prefixed identifiers mapped by UniProt in the past.